### PR TITLE
BUG: When creating tmp project on run action fails if the CIService  is not running on localhost

### DIFF
--- a/client/src/go/toscactl/tosca/project.go
+++ b/client/src/go/toscactl/tosca/project.go
@@ -37,6 +37,14 @@ func (t *Provider) DeleteWorkspace(workspaceSessionID string ,ctx context.Contex
 }
 
 func (t *Provider) CreateProject(createProjectRequest ProjectCreateRequest,ctx context.Context) (*Workspace,error) {
+	provisionerURL,err:=t.getOrchestratorURL(APIworkspace)
+	if err!=nil{
+		return nil,err
+	}
+	return t.createProject(createProjectRequest, provisionerURL,ctx)
+}
+
+func (t *Provider) createProject(createProjectRequest ProjectCreateRequest,provisionerURL string,ctx context.Context) (*Workspace,error) {
 	if err:=checkProjectRequest(createProjectRequest);err!=nil{
 		return nil,err
 	}
@@ -71,11 +79,8 @@ func (t *Provider) CreateProject(createProjectRequest ProjectCreateRequest,ctx c
 		}
 	}
 	writer.Close()
-	url,err:=t.getOrchestratorURL(APIworkspace)
-	if err!=nil{
-		return nil,err
-	}
-	r, err := http.NewRequest("POST",url , body)
+
+	r, err := http.NewRequest("POST",provisionerURL , body)
 	if err!=nil{
 		return nil,err
 	}

--- a/client/src/go/toscactl/tosca/test.go
+++ b/client/src/go/toscactl/tosca/test.go
@@ -361,13 +361,13 @@ func (t *Provider) prepareWorkspace(testSuiteConfig TestSuiteConfiguration,ctx c
 		templateType = CreateFromDatabase
 	}
 	rndNumber := rand.Intn(1000 - 1) + 1
-	workspace,err :=t.CreateProject(ProjectCreateRequest{
+	workspace,err :=t.createProject(ProjectCreateRequest{
 		SourcePath:               testSuiteConfig.Project.SourcePath,
 		Name:                     fmt.Sprintf("%s%d",testSuiteConfig.Name,rndNumber),
 		TemplateType:             templateType,
 		TemplateConnectionString: testSuiteConfig.Project.SourceConnectionStringDB,
 		DBType:                   LocalDB,
-	},ctx)
+	},testSuiteConfig.Agent.Hostname,ctx)
 	if err!=nil {
 		return nil,err
 	}


### PR DESCRIPTION
BUG: When creating tmp project on run action fails if the CIService is not running on localhost because it's using orchestratorURL instead of agentURL
